### PR TITLE
Immunopeptides fixes

### DIFF
--- a/bopep/docking/boltz_docker.py
+++ b/bopep/docking/boltz_docker.py
@@ -41,6 +41,7 @@ class BoltzDocker(BaseDockingModel):
         self.output_format = kwargs.get("output_format", "pdb")
         self.sampling_steps = kwargs.get("sampling_steps", 200)
         self.step_scale = kwargs.get("step_scale", 1.638)
+        self.cache = kwargs.get("cache") or kwargs.get("cache_dir")
         
     def dock(self, peptide_sequences: List[str], target_structure: str, 
              target_sequence: str, target_name: str) -> List[str]:
@@ -76,7 +77,7 @@ class BoltzDocker(BaseDockingModel):
         """
         Get Boltz-specific parameters for parallel processing.
         """
-        return {
+        params = {
             'recycling_steps': self.recycling_steps,
             'diffusion_samples': self.diffusion_samples,
             'output_format': self.output_format,
@@ -84,6 +85,7 @@ class BoltzDocker(BaseDockingModel):
             'step_scale': self.step_scale,
             'overwrite_results': self.overwrite_results
         }
+        return params
     
     @staticmethod
     def _dock_peptides_for_gpu(peptides: List[str], gpu_id: str, target_structure: str,
@@ -108,7 +110,7 @@ class BoltzDocker(BaseDockingModel):
                 peptide, target_structure, target_sequence, target_name, gpu_id
             )
             docked_dirs.append(dir_path)
- 
+        
         
         return docked_dirs
     
@@ -186,6 +188,8 @@ class BoltzDocker(BaseDockingModel):
             "--step_scale", str(self.step_scale)
         ]
         
+        if getattr(self, 'cache', None):
+            cmd.extend(["--cache", self.cache])
         
         if self.overwrite_results:
             cmd.append("--override")
@@ -193,6 +197,8 @@ class BoltzDocker(BaseDockingModel):
         env = os.environ.copy()
         env["CUDA_VISIBLE_DEVICES"] = gpu_id
         env.pop("MPLBACKEND", None)
+        if getattr(self, 'cache', None):
+            env["BOLTZ_CACHE"] = self.cache
         
         logging.info(f"Running Boltz command: {' '.join(cmd)}")
         
@@ -404,4 +410,4 @@ class BoltzDocker(BaseDockingModel):
                     metrics["pde_matrix"] = pde_matrix  # Updated key name
                     logging.info(f"Extracted PDE matrix for model {best_model_id} with shape: {np.array(pde_matrix).shape}")
 
-                
+

--- a/bopep/scoring/is_peptide_in_binding_site.py
+++ b/bopep/scoring/is_peptide_in_binding_site.py
@@ -174,16 +174,15 @@ def is_peptide_in_binding_site_pdb_file(
         pdb_file, threshold=threshold
     )
 
+    nr_contact_residues = 0
     if binding_site_residue_indices is not None:
         # if any receptor_binding_site_indices is in the binding_site_residue_indices, return True
-        nr_contact_residues = 0
         for receptor_index in receptor_binding_site_indices:
             if receptor_index in binding_site_residue_indices:
                 nr_contact_residues += 1
 
     if nr_contact_residues >= required_n_contact_residues:
         return nr_contact_residues, True
-
     else:
         return nr_contact_residues, False
 

--- a/bopep/scoring/is_peptide_in_binding_site.py
+++ b/bopep/scoring/is_peptide_in_binding_site.py
@@ -1,9 +1,8 @@
 from typing import Tuple
-from Bio.PDB import PDBParser
+from Bio.PDB import PDBParser, MMCIFParser
 import numpy as np
 from scipy.spatial import cKDTree
 import os
-import re
 import math
 
 
@@ -88,7 +87,10 @@ def get_binding_site(
         (receptor_binding_site_atoms, receptor_binding_site_residue_indices,
          peptide_binding_site_residue_indices, peptide_atoms)
     """
-    parser = PDBParser(QUIET=True)
+    if pdb_file.endswith('.cif'):
+        parser = MMCIFParser(QUIET=True)
+    else:
+        parser = PDBParser(QUIET=True)
     try:
         structure = parser.get_structure("docked", pdb_file)
     except Exception as e:

--- a/bopep/scoring/is_peptide_in_binding_site.py
+++ b/bopep/scoring/is_peptide_in_binding_site.py
@@ -88,7 +88,7 @@ def get_binding_site(
          peptide_binding_site_residue_indices, peptide_atoms)
     """
     if pdb_file.endswith('.cif'):
-        parser = MMCIFParser(QUIET=True)
+        parser = MMCIFParser(QUIET=True, auth_residues=False)
     else:
         parser = PDBParser(QUIET=True)
     try:
@@ -106,6 +106,12 @@ def get_binding_site(
         min_peptide_residue_id = min(
             residue.id[1]
             for residue in peptide_chain.get_residues()
+            if residue.id[0] == " "
+        )
+
+        min_receptor_residue_id = min(
+            residue.id[1]
+            for residue in receptor_chain.get_residues()
             if residue.id[0] == " "
         )
 
@@ -129,7 +135,7 @@ def get_binding_site(
             indices = peptide_tree.query_ball_point(atom.coord, threshold)
             if indices:
                 receptor_binding_site_residue_indices.add(
-                    atom.get_parent().id[1]
+                    atom.get_parent().id[1] - min_receptor_residue_id # TODO: We need to check if this is correct
                 ) # E4
                 for idx in indices:
                     peptide_binding_site_residue_indices.add(

--- a/bopep/scoring/model_overlap.py
+++ b/bopep/scoring/model_overlap.py
@@ -5,11 +5,11 @@ import os
 import glob
 from itertools import combinations
 
-def rmsd(coords1, coords2):
+def rmsd(coords1 : np.ndarray, coords2 : np.ndarray) -> float:
     return np.sqrt(np.mean(np.sum((coords1 - coords2) ** 2, axis=1)))
 
 def align_and_compute_rmsd(
-    ref_pdb_file, pdb_file, peptide_sequence,
+    ref_pdb_file : str, pdb_file : str, peptide_sequence :str,
 ):
     """
     Given multiple PDBs, align each structure's receptor (chain A by default)
@@ -52,7 +52,7 @@ def align_and_compute_rmsd(
     return rmsd(ref_pep_coords, new_pep_coords_aligned)
 
 
-def compute_intra_model_rmsd(processed_dir, peptide_sequence):
+def compute_intra_model_rmsd(processed_dir : str, peptide_sequence : str):
     """
     Compute intra-model RMSD metrics for peptide chains within and across docking methods.
     """

--- a/bopep/scoring/pep_prot_distance.py
+++ b/bopep/scoring/pep_prot_distance.py
@@ -6,7 +6,7 @@ Distance-based loss function for protein-peptide interactions.
 """
 
 
-def distance_score_from_pdb(pdb_file_path, receptor_chain="A", peptide_chain="B", threshold=8.0):
+def distance_score_from_pdb(pdb_file_path : str, receptor_chain : str ="A", peptide_chain : str ="B", threshold : float = 8.0):
     """
     1) Parses the PDB to get coordinates/bfactors
     2) Computes the distance-based score

--- a/bopep/scoring/rosetta_scorer.py
+++ b/bopep/scoring/rosetta_scorer.py
@@ -1,5 +1,5 @@
 class RosettaScorer:
-    def __init__(self, pdb_file):
+    def __init__(self, pdb_file : str):
         self.pdb_file = pdb_file
         self.initialized = False
         self.scorefxn = None

--- a/bopep/scoring/scorer.py
+++ b/bopep/scoring/scorer.py
@@ -227,11 +227,17 @@ class Scorer:
             scores["alphafold_n_contacts"] = n_contacts
         
         if "alphafold_in_binding_site_score" in scores_to_include:
-            scores["alphafold_in_binding_site_score"] = smooth_peptide_binding_site_score(
-                alphafold_model_file, binding_site_residue_indices, threshold=5.0, alpha=1)
+            if binding_site_residue_indices is not None:
+                scores["alphafold_in_binding_site_score"] = smooth_peptide_binding_site_score(
+                    alphafold_model_file, binding_site_residue_indices, threshold=5.0, alpha=1)
+            else:
+                scores["alphafold_in_binding_site_score"] = None
         
         if "alphafold_template_rmsd" in scores_to_include:
-            scores["alphafold_template_rmsd"] = align_and_compute_rmsd(template_pdb, alphafold_model_file, peptide_sequence)
+            if template_pdb is not None:
+                scores["alphafold_template_rmsd"] = align_and_compute_rmsd(template_pdb, alphafold_model_file, peptide_sequence)
+            else:
+                scores["alphafold_template_rmsd"] = None
         
         # AlphaFold confidence scores
         if "alphafold_peptide_plddt" in scores_to_include:
@@ -308,11 +314,17 @@ class Scorer:
             scores["boltz_n_contacts"] = n_contacts
         
         if "boltz_in_binding_site_score" in scores_to_include:
-            scores["boltz_in_binding_site_score"] = smooth_peptide_binding_site_score(
-                boltz_model_file, binding_site_residue_indices, threshold=5.0, alpha=1)
+            if binding_site_residue_indices is not None:
+                scores["boltz_in_binding_site_score"] = smooth_peptide_binding_site_score(
+                    boltz_model_file, binding_site_residue_indices, threshold=5.0, alpha=1)
+            else:
+                scores["boltz_in_binding_site_score"] = None
         
         if "boltz_template_rmsd" in scores_to_include:
-            scores["boltz_template_rmsd"] = align_and_compute_rmsd(template_pdb, boltz_model_file, peptide_sequence)
+            if template_pdb is not None:
+                scores["boltz_template_rmsd"] = align_and_compute_rmsd(template_pdb, boltz_model_file, peptide_sequence)
+            else:
+                scores["boltz_template_rmsd"] = None
         
         # Boltz confidence scores
         if "boltz_peptide_plddt" in scores_to_include:
@@ -362,11 +374,17 @@ class Scorer:
             scores["n_contacts"] = n_contacts
         
         if "in_binding_site_score" in scores_to_include:
-            scores["in_binding_site_score"] = smooth_peptide_binding_site_score(
-                target_pdb_file, binding_site_residue_indices, threshold=5.0, alpha=1)
+            if binding_site_residue_indices is not None:
+                scores["in_binding_site_score"] = smooth_peptide_binding_site_score(
+                    target_pdb_file, binding_site_residue_indices, threshold=5.0, alpha=1)
+            else:
+                scores["in_binding_site_score"] = None
         
         if "template_rmsd" in scores_to_include:
-            scores["template_rmsd"] = align_and_compute_rmsd(template_pdb, target_pdb_file, peptide_sequence)
+            if template_pdb is not None:
+                scores["template_rmsd"] = align_and_compute_rmsd(template_pdb, target_pdb_file, peptide_sequence)
+            else:
+                scores["template_rmsd"] = None
         
         # Generic confidence scores (previously exclusive; now include both method-specific if both present)
         if "peptide_plddt" in scores_to_include:
@@ -499,7 +517,7 @@ class Scorer:
         scores_to_include : list
             List of score names to include (same as in score method)
         inputs : list
-            List of inputs based on input_type (pdb_files, colab_dirs, or peptide_sequences)
+            List of inputs based on input_type (pdb_files, processed_dir, or peptide_sequences)
         input_type : str
             Type of input: "pdb_file", "processed_dir", or "peptide_sequence"
         binding_site_residue_indices : list, optional

--- a/bopep/scoring/scorer.py
+++ b/bopep/scoring/scorer.py
@@ -368,114 +368,112 @@ class Scorer:
         if "template_rmsd" in scores_to_include:
             scores["template_rmsd"] = align_and_compute_rmsd(template_pdb, target_pdb_file, peptide_sequence)
         
-        # Generic confidence scores (use available method)
+        # Generic confidence scores (previously exclusive; now include both method-specific if both present)
         if "peptide_plddt" in scores_to_include:
-            if has_alphafold and alphafold_model_file and has_boltz and boltz_model_file:
-                raise ValueError("Multiple methods available for 'peptide_plddt'. Use 'alphafold_peptide_plddt' or 'boltz_peptide_plddt'")
-            elif has_alphafold and alphafold_model_file:
-                peptide_plddt = get_peptide_plddt(alphafold_data.get("plddt", []), alphafold_model_file)
-                scores["peptide_plddt"] = peptide_plddt
-            elif has_boltz and boltz_model_file:
-                peptide_plddt = get_peptide_plddt(boltz_data.get("plddt", []), boltz_model_file)
-                scores["peptide_plddt"] = peptide_plddt
-            else:
+            added = False
+            if has_alphafold and alphafold_model_file:
+                scores["alphafold_peptide_plddt"] = get_peptide_plddt(alphafold_data.get("plddt", []), alphafold_model_file)
+                added = True
+            if has_boltz and boltz_model_file:
+                scores["boltz_peptide_plddt"] = get_peptide_plddt(boltz_data.get("plddt", []), boltz_model_file)
+                added = True
+            if not added:
                 raise ValueError("peptide_plddt requires docking output with model file")
+            if has_alphafold ^ has_boltz:  # only one method available -> keep generic alias
+                scores["peptide_plddt"] = scores.get("alphafold_peptide_plddt") or scores.get("boltz_peptide_plddt")
         
         if "interface_peptide_plddt" in scores_to_include:
-            if has_alphafold and alphafold_model_file and has_boltz and boltz_model_file:
-                raise ValueError("Multiple methods available for 'interface_peptide_plddt'. Use 'alphafold_interface_peptide_plddt' or 'boltz_interface_peptide_plddt'")
-            elif has_alphafold and alphafold_model_file:
-                interface_peptide_plddt = get_weighted_peptide_plddt(alphafold_data.get("plddt", []), alphafold_model_file)
-                scores["interface_peptide_plddt"] = interface_peptide_plddt
-            elif has_boltz and boltz_model_file:
-                interface_peptide_plddt = get_weighted_peptide_plddt(boltz_data.get("plddt", []), boltz_model_file)
-                scores["interface_peptide_plddt"] = interface_peptide_plddt
-            else:
+            added = False
+            if has_alphafold and alphafold_model_file:
+                scores["alphafold_interface_peptide_plddt"] = get_weighted_peptide_plddt(alphafold_data.get("plddt", []), alphafold_model_file)
+                added = True
+            if has_boltz and boltz_model_file:
+                scores["boltz_interface_peptide_plddt"] = get_weighted_peptide_plddt(boltz_data.get("plddt", []), boltz_model_file)
+                added = True
+            if not added:
                 raise ValueError("interface_peptide_plddt requires docking output with model file")
+            if has_alphafold ^ has_boltz:
+                scores["interface_peptide_plddt"] = scores.get("alphafold_interface_peptide_plddt") or scores.get("boltz_interface_peptide_plddt")
         
         if "peptide_pae" in scores_to_include:
-            if has_alphafold and alphafold_model_file and has_boltz and boltz_model_file:
-                raise ValueError("Multiple methods available for 'peptide_pae'. Use 'alphafold_peptide_pae' or 'boltz_peptide_pae'")
-            elif has_alphafold and alphafold_model_file:
-                peptide_pae = get_peptide_pae(alphafold_data.get("pae_matrix", []), alphafold_model_file)
-                scores["peptide_pae"] = peptide_pae
-            elif has_boltz and boltz_model_file:
-                peptide_pae = get_peptide_pae(boltz_data.get("pae_matrix", []), boltz_model_file)
-                scores["peptide_pae"] = peptide_pae
-            else:
-                raise ValueError("peptide_pae requires docking output with model file")
-            
-        if "peptide_pde" in scores_to_include:
+            # Normalize PAE key names
+            if "pae_matrix" not in alphafold_data and "pae" in alphafold_data:
+                alphafold_data["pae_matrix"] = alphafold_data["pae"]
+            if "pae_matrix" not in boltz_data and "pae" in boltz_data:
+                boltz_data["pae_matrix"] = boltz_data["pae"]
+            added = False
+            if has_alphafold and alphafold_model_file:
+                scores["alphafold_peptide_pae"] = get_peptide_pae(alphafold_data.get("pae_matrix", []), alphafold_model_file)
+                added = True
             if has_boltz and boltz_model_file:
-                peptide_pde = get_peptide_pde(boltz_data.get("pde_matrix", []), boltz_model_file)
-                scores["peptide_pde"] = peptide_pde
+                scores["boltz_peptide_pae"] = get_peptide_pae(boltz_data.get("pae_matrix", []), boltz_model_file)
+                added = True
+            if not added:
+                raise ValueError("peptide_pae requires docking output with model file")
+            if has_alphafold ^ has_boltz: # XOR (^) means this is only true when one method is available :)
+                scores["peptide_pae"] = scores.get("alphafold_peptide_pae") or scores.get("boltz_peptide_pae")
+        
+        if "peptide_pde" in scores_to_include:
+            # Only Boltz currently provides PDE
+            if has_boltz and boltz_model_file:
+                scores["boltz_peptide_pde"] = get_peptide_pde(boltz_data.get("pde_matrix", []), boltz_model_file)
+                scores["peptide_pde"] = scores["boltz_peptide_pde"]  # always expose generic alias since single source
             else:
                 raise ValueError("peptide_pde requires Boltz output with model file")
-            
+        
         if "intra_model_rmsd" in scores_to_include:
             if not processed_dir:
                 raise ValueError("intra_model_rmsd requires processed directory with model files")
             scores.update(compute_intra_model_rmsd(processed_dir, peptide_sequence))
         
-        # Generic docking scores (use available method)
+        # Generic docking scores (iptm) now collect both if present; generic alias only if one
         if "iptm" in scores_to_include:
-            if has_alphafold and has_boltz:
-                raise ValueError("Multiple methods available for 'iptm'. Use 'alphafold_iptm' or 'boltz_iptm'")
-            elif has_alphafold:
-                scores["iptm"] = alphafold_data.get("iptm")
-            elif has_boltz:
-                scores["iptm"] = boltz_data.get("iptm")
-            else:
+            added = False
+            if has_alphafold:
+                scores["alphafold_iptm"] = alphafold_data.get("iptm")
+                added = True
+            if has_boltz:
+                scores["boltz_iptm"] = boltz_data.get("iptm")
+                added = True
+            if not added:
                 raise ValueError("iptm requires docking output")
-            
+            if has_alphafold ^ has_boltz:
+                scores["iptm"] = scores.get("alphafold_iptm") or scores.get("boltz_iptm")
+        
         if "inter_model_rmsd" in scores_to_include:
             if has_boltz and boltz_model_file and has_alphafold and alphafold_model_file:
                 scores["inter_model_rmsd"] = align_and_compute_rmsd(boltz_model_file, alphafold_model_file, peptide_sequence)
-            else:                
+            else:
                 raise ValueError("inter_model_rmsd requires both Boltz and AlphaFold model files")
         
         if "peptide_properties" in scores_to_include:
             scores.update(peptide_properties.get_all_properties())
-        
         if "molecular_weight" in scores_to_include:
             scores["molecular_weight"] = peptide_properties.get_molecular_weight()
-        
         if "aromaticity" in scores_to_include:
             scores["aromaticity"] = peptide_properties.get_aromaticity()
-        
         if "instability_index" in scores_to_include:
             scores["instability_index"] = peptide_properties.get_instability_index()
-        
         if "isoelectric_point" in scores_to_include:
             scores["isoelectric_point"] = peptide_properties.get_isoelectric_point()
-        
         if "gravy" in scores_to_include:
             scores["gravy"] = peptide_properties.get_gravy()
-        
         if "helix_fraction" in scores_to_include:
             scores["helix_fraction"] = peptide_properties.get_helix_fraction()
-        
         if "turn_fraction" in scores_to_include:
             scores["turn_fraction"] = peptide_properties.get_turn_fraction()
-        
         if "sheet_fraction" in scores_to_include:
             scores["sheet_fraction"] = peptide_properties.get_sheet_fraction()
-        
         if "hydrophobic_aa_percent" in scores_to_include:
             scores["hydrophobic_aa_percent"] = peptide_properties.get_hydrophobic_aa_percent()
-        
         if "polar_aa_percent" in scores_to_include:
             scores["polar_aa_percent"] = peptide_properties.get_polar_aa_percent()
-        
         if "positively_charged_aa_percent" in scores_to_include:
             scores["positively_charged_aa_percent"] = peptide_properties.get_positively_charged_aa_percent()
-        
         if "negatively_charged_aa_percent" in scores_to_include:
             scores["negatively_charged_aa_percent"] = peptide_properties.get_negatively_charged_aa_percent()
-        
         if "delta_net_charge_frac" in scores_to_include:
             scores["delta_net_charge_frac"] = peptide_properties.get_delta_net_charge_frac()
-        
         if "uHrel" in scores_to_include:
             scores["uHrel"] = peptide_properties.get_uHrel()
         

--- a/bopep/scoring/scorer.py
+++ b/bopep/scoring/scorer.py
@@ -3,7 +3,7 @@ import multiprocessing
 import traceback
 import json
 import glob
-from typing import Optional, List
+from typing import Optional
 from bopep.scoring.pep_prot_distance import distance_score_from_pdb
 from bopep.scoring.rosetta_scorer import RosettaScorer
 from bopep.scoring.is_peptide_in_binding_site import (

--- a/bopep/scoring/scorer.py
+++ b/bopep/scoring/scorer.py
@@ -243,7 +243,7 @@ class Scorer:
             scores["alphafold_interface_peptide_plddt"] = interface_peptide_plddt
 
         if "alphafold_peptide_pae" in scores_to_include:
-            peptide_pae = get_peptide_pae(alphafold_data.get("pae_matrix", []), alphafold_model_file)
+            peptide_pae = get_peptide_pae(alphafold_data.get("pae", []), alphafold_model_file)
             scores["alphafold_peptide_pae"] = peptide_pae
 
         # Boltz docking scores

--- a/bopep/scoring/utils.py
+++ b/bopep/scoring/utils.py
@@ -36,7 +36,7 @@ def parse_pdb(pdb_file_path, receptor_chain="A", peptide_chain="B"):
     )
     """
     if pdb_file_path.endswith('.cif'):
-        parser = MMCIFParser(QUIET=True)
+        parser = MMCIFParser(QUIET=True, auth_residues=False)
     else:
         parser = PDBParser(QUIET=True)
     structure = parser.get_structure("complex", pdb_file_path)

--- a/bopep/scoring/utils.py
+++ b/bopep/scoring/utils.py
@@ -1,4 +1,4 @@
-from Bio.PDB import PDBParser
+from Bio.PDB import PDBParser, MMCIFParser
 from Bio.PDB.Polypeptide import is_aa
 from Bio.Data.IUPACData import protein_letters_3to1
 import os
@@ -35,8 +35,11 @@ def parse_pdb(pdb_file_path, receptor_chain="A", peptide_chain="B"):
         peptide_coords: list of (x, y, z),
     )
     """
-    parser = PDBParser(QUIET=True)
-    structure = parser.get_structure(id="complex", file=pdb_file_path)
+    if pdb_file_path.endswith('.cif'):
+        parser = MMCIFParser(QUIET=True)
+    else:
+        parser = PDBParser(QUIET=True)
+    structure = parser.get_structure("complex", pdb_file_path)
 
     receptor_coords = []
     peptide_coords = []
@@ -89,7 +92,10 @@ def get_plDDT_from_dir(colab_dir, rank_num : int = 1):
         return None
 
 def get_chain_sequences(pdb_file):
-     parser = PDBParser(QUIET=True)
+     if pdb_file.endswith('.cif'):
+         parser = MMCIFParser(QUIET=True)
+     else:
+         parser = PDBParser(QUIET=True)
      structure = parser.get_structure('struct', pdb_file)
      return {chain.id: ''.join([
          protein_letters_3to1.get(residue.get_resname().capitalize(), 'X')

--- a/bopep/scoring/utils.py
+++ b/bopep/scoring/utils.py
@@ -5,7 +5,7 @@ import os
 import json
 import re
 
-def find_relaxed_pdb_file(colab_dir):
+def find_relaxed_pdb_file(colab_dir : str):
     """
     Finds the relaxed rank_001 PDB file in the colab directory.
     
@@ -21,7 +21,7 @@ def find_relaxed_pdb_file(colab_dir):
     return None
 
 
-def parse_pdb(pdb_file_path, receptor_chain="A", peptide_chain="B"):
+def parse_pdb(pdb_file_path : str, receptor_chain : str="A", peptide_chain : str="B"):
     """
     Parses a PDB file using BioPython and returns coordinates & B-factors
     for receptor and peptide atoms separately.
@@ -64,7 +64,7 @@ def parse_pdb(pdb_file_path, receptor_chain="A", peptide_chain="B"):
     return receptor_coords, peptide_coords
 
 
-def get_plDDT_from_dir(colab_dir, rank_num : int = 1):
+def get_plDDT_from_dir(colab_dir : str, rank_num : int = 1):
     """
     Extracts the plDDT score from an unzipped docking result directory.
     """
@@ -91,7 +91,7 @@ def get_plDDT_from_dir(colab_dir, rank_num : int = 1):
         print(f"Error reading JSON file: {e}")
         return None
 
-def get_chain_sequences(pdb_file):
+def get_chain_sequences(pdb_file : str):
      if pdb_file.endswith('.cif'):
          parser = MMCIFParser(QUIET=True)
      else:
@@ -102,7 +102,7 @@ def get_chain_sequences(pdb_file):
          for residue in chain if residue.id[0] == ' '
      ]) for model in structure for chain in model}
 
-def match_and_truncate(ref_seq, ref_coords, target_seq, target_coords):
+def match_and_truncate(ref_seq :  str, ref_coords : list, target_seq : str, target_coords : list):
     if ref_seq in target_seq:
         i = target_seq.index(ref_seq)
         return ref_coords, target_coords[i:i+len(ref_seq)]

--- a/bopep/search/pdb_utils.py
+++ b/bopep/search/pdb_utils.py
@@ -50,6 +50,12 @@ def _check_binding_site_residue_indices(
     
     if binding_site_residue_indices is None:
         return None
+    
+    for residue in binding_site_residue_indices:
+        if residue < 0 or residue >= len(protein_sequence):
+            raise ValueError(
+                f"Binding site residue index {residue} is out of range for protein sequence of length {len(protein_sequence)}"
+            )
 
     # Handle both list and dict formats
     is_dict_format = isinstance(binding_site_residue_indices, dict)
@@ -114,7 +120,9 @@ def _check_binding_site_residue_indices(
     for residue_idx in residues_to_check:
         if residue_idx < 0 or residue_idx >= len(protein_sequence):
             print(f"Warning: Residue index {residue_idx} out of range")
-            continue
+            raise ValueError(
+                f"Binding site residue index {residue_idx} is out of range for protein sequence of length {len(protein_sequence)}"
+            )
 
         # Calculate start and end positions for context
         start = max(0, residue_idx - context_size)


### PR DESCRIPTION
All bugs found during implementation of benchmarking. 

So far includes:
- Allow Boltz and AF scores to be jointly included in scores
- Allow custom cache location to be passed as it can grow quite large
- Added .cif parsing for template files (template_rmsd)
- Minor fix to pae scoring. Referenced pae_matrix in Alphafold json, only available was pae. pae_matrix -> pae.

To examine: Is truncation method robust? We dont want to accidentally truncate files when not necessary (template_rmsd).