### PR TITLE
Bugfix score index mismatch

### DIFF
--- a/bopep/scoring/is_peptide_in_binding_site.py
+++ b/bopep/scoring/is_peptide_in_binding_site.py
@@ -146,7 +146,7 @@ def get_binding_site(
         receptor_binding_site_atoms = [
             atom
             for residue in receptor_chain
-            if residue.id[1] in receptor_binding_site_residue_indices
+            if (residue.id[1] - min_receptor_residue_id) in receptor_binding_site_residue_indices
             for atom in residue.get_atoms()
         ]            
 

--- a/bopep/scoring/is_peptide_in_binding_site.py
+++ b/bopep/scoring/is_peptide_in_binding_site.py
@@ -100,24 +100,26 @@ def get_binding_site(
     try:
         model = structure[0]
 
-        receptor_chain = model[receptor_chain]
-        peptide_chain = model[peptide_chain]
+        receptor_chain_obj = model[receptor_chain]
+        peptide_chain_obj = model[peptide_chain]
+        
+        # Filter to only standard amino acid residues immediately after parsing
+        receptor_residues = [res for res in receptor_chain_obj.get_residues() if res.id[0] == " "]
+        peptide_residues = [res for res in peptide_chain_obj.get_residues() if res.id[0] == " "]
+        
+        if not receptor_residues or not peptide_residues:
+            return [], [], [], []
 
-        min_peptide_residue_id = min(
-            residue.id[1]
-            for residue in peptide_chain.get_residues()
-            if residue.id[0] == " "
-        )
+        receptor_residue_map = {i: res for i, res in enumerate(receptor_residues)}
+        peptide_residue_map = {i: res for i, res in enumerate(peptide_residues)}
+        
+        # Create reverse mapping from PDB residue ID to zero-based index
+        receptor_pdb_to_zero = {res.id[1]: i for i, res in enumerate(receptor_residues)}
+        peptide_pdb_to_zero = {res.id[1]: i for i, res in enumerate(peptide_residues)}
 
-        min_receptor_residue_id = min(
-            residue.id[1]
-            for residue in receptor_chain.get_residues()
-            if residue.id[0] == " "
-        )
-
-        # Get all atoms from both chains
-        receptor_atoms = list(receptor_chain.get_atoms())
-        peptide_atoms = list(peptide_chain.get_atoms())
+        # Get all atoms from filtered residues
+        receptor_atoms = [atom for res in receptor_residues for atom in res.get_atoms()]
+        peptide_atoms = [atom for res in peptide_residues for atom in res.get_atoms()]
 
         if not receptor_atoms or not peptide_atoms:
             return [], [], [], []
@@ -126,28 +128,30 @@ def get_binding_site(
         peptide_coords = np.array([atom.coord for atom in peptide_atoms])
         peptide_tree = cKDTree(peptide_coords)
 
-        # Find interacting residues
+        # Find interacting residues (using zero-based indices)
         receptor_binding_site_residue_indices = set()
         peptide_binding_site_residue_indices = set()
 
         # For each receptor atom, find peptide atoms within threshold
-        for i, atom in enumerate(receptor_atoms): # This will be 1-indexed
+        for atom in receptor_atoms:
             indices = peptide_tree.query_ball_point(atom.coord, threshold)
             if indices:
-                receptor_binding_site_residue_indices.add(
-                    atom.get_parent().id[1] - min_receptor_residue_id # TODO: We need to check if this is correct
-                ) # E4
+                # Get zero-based index for receptor residue
+                receptor_pdb_id = atom.get_parent().id[1]
+                if receptor_pdb_id in receptor_pdb_to_zero:
+                    receptor_binding_site_residue_indices.add(receptor_pdb_to_zero[receptor_pdb_id])
+                
+                # Get zero-based indices for peptide residues
                 for idx in indices:
-                    peptide_binding_site_residue_indices.add(
-                        peptide_atoms[idx].get_parent().id[1] - min_peptide_residue_id
-                    )
+                    peptide_pdb_id = peptide_atoms[idx].get_parent().id[1]
+                    if peptide_pdb_id in peptide_pdb_to_zero:
+                        peptide_binding_site_residue_indices.add(peptide_pdb_to_zero[peptide_pdb_id])
 
-        # Get the atoms from the binding site residues
+        # Get the atoms from the binding site residues (using zero-based indices)
         receptor_binding_site_atoms = [
             atom
-            for residue in receptor_chain
-            if (residue.id[1] - min_receptor_residue_id) in receptor_binding_site_residue_indices
-            for atom in residue.get_atoms()
+            for zero_idx in receptor_binding_site_residue_indices
+            for atom in receptor_residue_map[zero_idx].get_atoms()
         ]            
 
 

--- a/bopep/scoring/model_overlap.py
+++ b/bopep/scoring/model_overlap.py
@@ -18,38 +18,45 @@ def align_and_compute_rmsd(
     Each structure's receptor is aligned to the first PDB's receptor, then
     peptide RMSD is computed between all pairs of aligned structures.
     """
- 
-    ref_chain_seqs = get_chain_sequences(ref_pdb_file)
-    new_chain_seqs = get_chain_sequences(pdb_file)
-    if len(ref_chain_seqs) != 2:
-        raise ValueError("Reference PDB must have exactly two chains.")
-    ref_keys = list(ref_chain_seqs.keys())
+    try:
+        ref_chain_seqs = get_chain_sequences(ref_pdb_file)
+        new_chain_seqs = get_chain_sequences(pdb_file)
+        if len(ref_chain_seqs) != 2:
+            raise ValueError("Reference PDB must have exactly two chains.")
+        ref_keys = list(ref_chain_seqs.keys())
 
-    # Assign peptide/receptor chains by sequence match
+        # Assign peptide/receptor chains by sequence match
+        
+        pairs = [
+            (ref_keys[0], ref_keys[1]),
+            (ref_keys[1], ref_keys[0])
+        ]
+        for pep_id, rec_id in pairs:
+            if ref_chain_seqs[pep_id] == peptide_sequence:
+                ref_pep_chain_id =  pep_id
+                ref_rec_chain_id, ref_rec_seq = rec_id, ref_chain_seqs[rec_id]
+                break
+        else:
+            raise ValueError("The peptide sequence found in reference chains does not match the new peptide sequence.")
+
+        ref_rec_coords, ref_pep_coords = map(np.array, parse_pdb(ref_pdb_file, ref_rec_chain_id, ref_pep_chain_id))
+        new_rec_coords, new_pep_coords = map(np.array, parse_pdb(pdb_file, "A", "B"))
+        new_rec_seq = new_chain_seqs.get("A", "")
+
+        ref_rec_coords_trunc, new_rec_coords_trunc = match_and_truncate(ref_rec_seq, ref_rec_coords, new_rec_seq, new_rec_coords)
+        sup = SVDSuperimposer()
+        sup.set(ref_rec_coords_trunc, new_rec_coords_trunc)
+        sup.run()
+        rot, tran = sup.get_rotran()
+        new_pep_coords_aligned = np.dot(new_pep_coords, rot) + tran
+        return rmsd(ref_pep_coords, new_pep_coords_aligned)
     
-    pairs = [
-        (ref_keys[0], ref_keys[1]),
-        (ref_keys[1], ref_keys[0])
-    ]
-    for pep_id, rec_id in pairs:
-        if ref_chain_seqs[pep_id] == peptide_sequence:
-            ref_pep_chain_id =  pep_id
-            ref_rec_chain_id, ref_rec_seq = rec_id, ref_chain_seqs[rec_id]
-            break
-    else:
-        raise ValueError("The peptide sequence found in reference chains does not match the new peptide sequence.")
-
-    ref_rec_coords, ref_pep_coords = map(np.array, parse_pdb(ref_pdb_file, ref_rec_chain_id, ref_pep_chain_id))
-    new_rec_coords, new_pep_coords = map(np.array, parse_pdb(pdb_file, "A", "B"))
-    new_rec_seq = new_chain_seqs.get("A", "")
-
-    ref_rec_coords_trunc, new_rec_coords_trunc = match_and_truncate(ref_rec_seq, ref_rec_coords, new_rec_seq, new_rec_coords)
-    sup = SVDSuperimposer()
-    sup.set(ref_rec_coords_trunc, new_rec_coords_trunc)
-    sup.run()
-    rot, tran = sup.get_rotran()
-    new_pep_coords_aligned = np.dot(new_pep_coords, rot) + tran
-    return rmsd(ref_pep_coords, new_pep_coords_aligned)
+    except Exception as e:
+        print(f"Warning: Template RMSD calculation failed: {e}")
+        print(f"  Reference file: {ref_pdb_file}")
+        print(f"  Target file: {pdb_file}")
+        print(f"  Peptide sequence: {peptide_sequence}")
+        return None
 
 
 def compute_intra_model_rmsd(processed_dir : str, peptide_sequence : str):

--- a/bopep/scoring/utils.py
+++ b/bopep/scoring/utils.py
@@ -110,4 +110,4 @@ def match_and_truncate(ref_seq :  str, ref_coords : list, target_seq : str, targ
         i = ref_seq.index(target_seq)
         return ref_coords[i:i+len(target_seq)], target_coords
     else:
-        raise ValueError("Could not match reference and target receptor sequences for alignment.")
+        raise ValueError(f"Could not match reference and target receptor sequences for alignment. Reference sequence: {ref_seq}, Target sequence: {target_seq}")


### PR DESCRIPTION
Binding site residues were being handled incorrectly when reading directly off of CIF files. This caused issues with various in_binding_site calculations, but the main pipeline is not harmed as it processes files that have already been parsed with more intelligent solutions.

We now pass on residues for which we do not have structural data. 